### PR TITLE
Custom page size

### DIFF
--- a/src/main/java/com/planbase/pdf/layoutmanager/LogicalPage.java
+++ b/src/main/java/com/planbase/pdf/layoutmanager/LogicalPage.java
@@ -17,21 +17,17 @@ public class LogicalPage { // AKA Document Section
 
     private final PdfLayoutMgr mgr;
     private final boolean portrait;
-    private final XyDim pageDim;
     // borderItems apply to a logical section
     private Set<PdfItem> borderItems = new TreeSet<PdfItem>();
     private int borderOrd = 0;
     boolean valid = true;
     
-    private float topMargin = 37;
-    private float bottomMargin = 0;
-    
     /** The Y-value for the top margin of the page (in document units) */
     @SuppressWarnings("UnusedDeclaration") // Part of end-user public interface
-    public float yPageTop() { return pageDim.y() - topMargin; }
+    public float yPageTop() { return mgr.pageHeight() - 37; }
     /** The Y-value for the bottom margin of the page (in document units) */
     @SuppressWarnings("UnusedDeclaration") // Part of end-user public interface
-    public float yPageBottom() { return portrait ? bottomMargin : 230; }
+    public float yPageBottom() { return portrait ? 0 : 230; }
 
     /** Height of the printable area (in document units) */
     @SuppressWarnings("UnusedDeclaration") // Part of end-user public interface
@@ -39,11 +35,11 @@ public class LogicalPage { // AKA Document Section
     /** Width of the printable area (in document units) */
     @SuppressWarnings("UnusedDeclaration") // Part of end-user public interface
     public float pageWidth() {
-        return portrait ? pageDim.x()
-                : pageDim.y();
+        return portrait ? mgr.pageWidth()
+                : mgr.pageHeight();
     }
 
-    private LogicalPage(PdfLayoutMgr m, boolean p) { mgr = m; portrait = p; pageDim = m.pageDim(); }
+    private LogicalPage(PdfLayoutMgr m, boolean p) { mgr = m; portrait = p; }
 
     public static LogicalPage of(PdfLayoutMgr m) { return new LogicalPage(m, false); }
     public static LogicalPage of(PdfLayoutMgr m, Orientation orientation) {
@@ -89,22 +85,6 @@ public class LogicalPage { // AKA Document Section
         pby.pb.drawPng(xVal, pby.y, sj, mgr);
         return this;
     }
-
-    public void topMargin(float topMargin) {
-	this.topMargin = topMargin;
-    }
-    
-    public float topMargin() {
-	return topMargin;
-    }
-    
-    public void bottomMargin(float bottomMargin) {
-	this.bottomMargin = bottomMargin;
-    }
-    
-    public float bottomMargin() {
-	return bottomMargin;
-    }	
 
     public LogicalPage putRect(XyOffset outerTopLeft, XyDim outerDimensions, final Color c) {
         if (!valid) { throw new IllegalStateException("Logical page accessed after commit"); }

--- a/src/main/java/com/planbase/pdf/layoutmanager/LogicalPage.java
+++ b/src/main/java/com/planbase/pdf/layoutmanager/LogicalPage.java
@@ -17,6 +17,7 @@ public class LogicalPage { // AKA Document Section
 
     private final PdfLayoutMgr mgr;
     private final boolean portrait;
+    private final XyDim pageDim;
     // borderItems apply to a logical section
     private Set<PdfItem> borderItems = new TreeSet<PdfItem>();
     private int borderOrd = 0;
@@ -27,7 +28,7 @@ public class LogicalPage { // AKA Document Section
     
     /** The Y-value for the top margin of the page (in document units) */
     @SuppressWarnings("UnusedDeclaration") // Part of end-user public interface
-    public float yPageTop() { return return mgr.getMediaBox().getHeight() - topMargin; }
+    public float yPageTop() { return pageDim.y() - topMargin; }
     /** The Y-value for the bottom margin of the page (in document units) */
     @SuppressWarnings("UnusedDeclaration") // Part of end-user public interface
     public float yPageBottom() { return portrait ? bottomMargin : 230; }
@@ -38,11 +39,11 @@ public class LogicalPage { // AKA Document Section
     /** Width of the printable area (in document units) */
     @SuppressWarnings("UnusedDeclaration") // Part of end-user public interface
     public float pageWidth() {
-        return portrait ? mgr.getMediaBox().getWidth()
-                : mgr.getMediaBox().getHeight();
+        return portrait ? pageDim.x()
+                : pageDim.y();
     }
 
-    private LogicalPage(PdfLayoutMgr m, boolean p) { mgr = m; portrait = p; }
+    private LogicalPage(PdfLayoutMgr m, boolean p) { mgr = m; portrait = p; pageDim = m.pageDim(); }
 
     public static LogicalPage of(PdfLayoutMgr m) { return new LogicalPage(m, false); }
     public static LogicalPage of(PdfLayoutMgr m, Orientation orientation) {
@@ -88,6 +89,22 @@ public class LogicalPage { // AKA Document Section
         pby.pb.drawPng(xVal, pby.y, sj, mgr);
         return this;
     }
+
+    public void topMargin(float topMargin) {
+	this.topMargin = topMargin;
+    }
+    
+    public float topMargin() {
+	return topMargin;
+    }
+    
+    public void bottomMargin(float bottomMargin) {
+	this.bottomMargin = bottomMargin;
+    }
+    
+    public float bottomMargin() {
+	return bottomMargin;
+    }	
 
     public LogicalPage putRect(XyOffset outerTopLeft, XyDim outerDimensions, final Color c) {
         if (!valid) { throw new IllegalStateException("Logical page accessed after commit"); }
@@ -288,14 +305,6 @@ public class LogicalPage { // AKA Document Section
         XyDim innerDim = cell.calcDimensions(outerWidth);
         return cell.render(this, XyOffset.of(x, origY), innerDim.x(outerWidth), true).y();
     }
-    
-    public void setTopMargin(float topMargin) {
-		this.topMargin = topMargin;
-	}
-    
-	public void setBottomMargin(float bottomMargin) {
-		this.bottomMargin = bottomMargin;
-	}
 
     void commitBorderItems(PDPageContentStream stream) throws IOException {
         if (!valid) { throw new IllegalStateException("Logical page accessed after commit"); }

--- a/src/main/java/com/planbase/pdf/layoutmanager/LogicalPage.java
+++ b/src/main/java/com/planbase/pdf/layoutmanager/LogicalPage.java
@@ -36,8 +36,8 @@ public class LogicalPage { // AKA Document Section
     /** Width of the printable area (in document units) */
     @SuppressWarnings("UnusedDeclaration") // Part of end-user public interface
     public float pageWidth() {
-        return portrait ? PDPage.PAGE_SIZE_LETTER.getWidth()
-                : PDPage.PAGE_SIZE_LETTER.getHeight();
+        return portrait ? PDPage.PAGE_SIZE_A4.getWidth()
+                : PDPage.PAGE_SIZE_A4.getHeight();
     }
 
     private LogicalPage(PdfLayoutMgr m, boolean p) { mgr = m; portrait = p; }

--- a/src/main/java/com/planbase/pdf/layoutmanager/LogicalPage.java
+++ b/src/main/java/com/planbase/pdf/layoutmanager/LogicalPage.java
@@ -1,6 +1,5 @@
 package com.planbase.pdf.layoutmanager;
 
-import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.edit.PDPageContentStream;
 
 import java.awt.Color;
@@ -22,13 +21,16 @@ public class LogicalPage { // AKA Document Section
     private Set<PdfItem> borderItems = new TreeSet<PdfItem>();
     private int borderOrd = 0;
     boolean valid = true;
-
+    
+    private float topMargin = 37;
+    private float bottomMargin = 0;
+    
     /** The Y-value for the top margin of the page (in document units) */
     @SuppressWarnings("UnusedDeclaration") // Part of end-user public interface
-    public float yPageTop() { return 755; }
+    public float yPageTop() { return return mgr.getMediaBox().getHeight() - topMargin; }
     /** The Y-value for the bottom margin of the page (in document units) */
     @SuppressWarnings("UnusedDeclaration") // Part of end-user public interface
-    public float yPageBottom() { return portrait ? 0 : 230; }
+    public float yPageBottom() { return portrait ? bottomMargin : 230; }
 
     /** Height of the printable area (in document units) */
     @SuppressWarnings("UnusedDeclaration") // Part of end-user public interface
@@ -36,8 +38,8 @@ public class LogicalPage { // AKA Document Section
     /** Width of the printable area (in document units) */
     @SuppressWarnings("UnusedDeclaration") // Part of end-user public interface
     public float pageWidth() {
-        return portrait ? PDPage.PAGE_SIZE_A4.getWidth()
-                : PDPage.PAGE_SIZE_A4.getHeight();
+        return portrait ? mgr.getMediaBox().getWidth()
+                : mgr.getMediaBox().getHeight();
     }
 
     private LogicalPage(PdfLayoutMgr m, boolean p) { mgr = m; portrait = p; }
@@ -286,6 +288,14 @@ public class LogicalPage { // AKA Document Section
         XyDim innerDim = cell.calcDimensions(outerWidth);
         return cell.render(this, XyOffset.of(x, origY), innerDim.x(outerWidth), true).y();
     }
+    
+    public void setTopMargin(float topMargin) {
+		this.topMargin = topMargin;
+	}
+    
+	public void setBottomMargin(float bottomMargin) {
+		this.bottomMargin = bottomMargin;
+	}
 
     void commitBorderItems(PDPageContentStream stream) throws IOException {
         if (!valid) { throw new IllegalStateException("Logical page accessed after commit"); }

--- a/src/main/java/com/planbase/pdf/layoutmanager/PdfLayoutMgr.java
+++ b/src/main/java/com/planbase/pdf/layoutmanager/PdfLayoutMgr.java
@@ -450,7 +450,7 @@ public class PdfLayoutMgr {
         // Write out all uncommitted pages.
         while (unCommittedPageIdx < pages.size()) {
             PDPage pdPage = new PDPage();
-            pdPage.setMediaBox(PDPage.PAGE_SIZE_LETTER);
+            pdPage.setMediaBox(PDPage.PAGE_SIZE_A4);
             if (lp.orientation() == LogicalPage.Orientation.LANDSCAPE) {
                 pdPage.setRotation(90);
             }

--- a/src/main/java/com/planbase/pdf/layoutmanager/PdfLayoutMgr.java
+++ b/src/main/java/com/planbase/pdf/layoutmanager/PdfLayoutMgr.java
@@ -17,6 +17,7 @@ package com.planbase.pdf.layoutmanager;
 import org.apache.pdfbox.exceptions.COSVisitorException;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.apache.pdfbox.pdmodel.edit.PDPageContentStream;
 import org.apache.pdfbox.pdmodel.graphics.color.PDColorSpace;
 import org.apache.pdfbox.pdmodel.graphics.color.PDDeviceRGB;
@@ -351,12 +352,20 @@ public class PdfLayoutMgr {
     private int unCommittedPageIdx = 0;
 
     private final PDColorSpace colorSpace;
+    private PDRectangle mediaBox;
 
     List<PageBuffer> pages() { return Collections.unmodifiableList(pages); }
 
     private PdfLayoutMgr(PDColorSpace cs) throws IOException {
         doc = new PDDocument();
         colorSpace = cs;
+        mediaBox = PDPage.PAGE_SIZE_LETTER;
+    }
+ 
+    private PdfLayoutMgr(PDColorSpace cs, PDRectangle mb) throws IOException {
+        doc = new PDDocument();
+        colorSpace = cs;
+        mediaBox = mb;
     }
 
     /**
@@ -377,6 +386,16 @@ public class PdfLayoutMgr {
     @SuppressWarnings("UnusedDeclaration") // Part of end-user public interface
     public static PdfLayoutMgr newRgbPageMgr() throws IOException {
         return new PdfLayoutMgr(PDDeviceRGB.INSTANCE);
+    }
+ 
+    /**
+    Creates a new PdfLayoutMgr with the PDDeviceRGB color space and a given mediaBox.
+    @return a new Page Manager with an RGB color space
+    @throws IOException
+    */
+    @SuppressWarnings("UnusedDeclaration") // Part of end-user public interface
+    public static PdfLayoutMgr newRgbPageMgr(PDRectangle mediaBox) throws IOException {
+        return new PdfLayoutMgr(PDDeviceRGB.INSTANCE, mediaBox);
     }
 
     /**
@@ -450,7 +469,7 @@ public class PdfLayoutMgr {
         // Write out all uncommitted pages.
         while (unCommittedPageIdx < pages.size()) {
             PDPage pdPage = new PDPage();
-            pdPage.setMediaBox(PDPage.PAGE_SIZE_A4);
+            pdPage.setMediaBox(this.mediaBox);
             if (lp.orientation() == LogicalPage.Orientation.LANDSCAPE) {
                 pdPage.setRotation(90);
             }
@@ -904,4 +923,7 @@ public class PdfLayoutMgr {
         return sB.toString();
     }
 
+    public PDRectangle getMediaBox() {
+     return this.mediaBox;
+    }
 }

--- a/src/main/java/com/planbase/pdf/layoutmanager/PdfLayoutMgr.java
+++ b/src/main/java/com/planbase/pdf/layoutmanager/PdfLayoutMgr.java
@@ -409,11 +409,19 @@ public class PdfLayoutMgr {
     }
     
     /**
-     Returns the pages dimension given the defined PDRectangle mediaBox
-     * @return an XyDim
+     Returns the page width given the defined PDRectangle mediaBox
+     * @return a float
      */
-    public XyDim pageDim() {
-        return XyDim.of(this.mediaBox.getWidth(), this.mediaBox.getHeight());
+    public float pageWidth() {
+        return this.mediaBox.getWidth();
+    }
+
+    /**
+    Returns the page height given the defined PDRectangle mediaBox
+    * @return a float
+    */
+    public float pageHeight() {
+        return this.mediaBox.getHeight();
     }
 
     /**

--- a/src/main/java/com/planbase/pdf/layoutmanager/PdfLayoutMgr.java
+++ b/src/main/java/com/planbase/pdf/layoutmanager/PdfLayoutMgr.java
@@ -352,7 +352,7 @@ public class PdfLayoutMgr {
     private int unCommittedPageIdx = 0;
 
     private final PDColorSpace colorSpace;
-    private PDRectangle mediaBox;
+    private final PDRectangle mediaBox;
 
     List<PageBuffer> pages() { return Collections.unmodifiableList(pages); }
 
@@ -389,13 +389,31 @@ public class PdfLayoutMgr {
     }
  
     /**
-    Creates a new PdfLayoutMgr with the PDDeviceRGB color space and a given mediaBox.
-    @return a new Page Manager with an RGB color space
+    Creates a new PdfLayoutMgr with the PDDeviceRGB color space and a mediaBox.
+    @return a new Page Manager with an RGB color space and a mediaBox
     @throws IOException
     */
     @SuppressWarnings("UnusedDeclaration") // Part of end-user public interface
     public static PdfLayoutMgr newRgbPageMgr(PDRectangle mediaBox) throws IOException {
         return new PdfLayoutMgr(PDDeviceRGB.INSTANCE, mediaBox);
+    }
+ 
+    /**
+    Creates a new PdfLayoutMgr with a custom PDDeviceRGB color space and a given mediaBox.
+    @return a new Page Manager with an RGB color space and a mediaBox
+    @throws IOException
+    */
+    @SuppressWarnings("UnusedDeclaration") // Part of end-user public interface
+    public static PdfLayoutMgr newRgbPageMgr(PDColorSpace cs, PDRectangle mediaBox) throws IOException {
+        return new PdfLayoutMgr(cs, mediaBox);
+    }
+    
+    /**
+     Returns the pages dimension given the defined PDRectangle mediaBox
+     * @return an XyDim
+     */
+    public XyDim pageDim() {
+        return XyDim.of(this.mediaBox.getWidth(), this.mediaBox.getHeight());
     }
 
     /**
@@ -468,8 +486,7 @@ public class PdfLayoutMgr {
 
         // Write out all uncommitted pages.
         while (unCommittedPageIdx < pages.size()) {
-            PDPage pdPage = new PDPage();
-            pdPage.setMediaBox(this.mediaBox);
+            PDPage pdPage = new PDPage(this.mediaBox);
             if (lp.orientation() == LogicalPage.Orientation.LANDSCAPE) {
                 pdPage.setRotation(90);
             }
@@ -921,9 +938,5 @@ public class PdfLayoutMgr {
             sB.append(in.subSequence(idx, in.length()));
         }
         return sB.toString();
-    }
-
-    public PDRectangle getMediaBox() {
-     return this.mediaBox;
     }
 }

--- a/src/main/java/com/planbase/pdf/layoutmanager/TextStyle.java
+++ b/src/main/java/com/planbase/pdf/layoutmanager/TextStyle.java
@@ -36,7 +36,7 @@ public class TextStyle {
     private final float descent;
     private final float leading;
 
-    private TextStyle(PDType1Font f, float sz, Color tc) {
+    private TextStyle(PDType1Font f, float sz, Color tc, float leadingFactor) {
         if (f == null) { throw new IllegalArgumentException("Font must not be null"); }
         if (tc == null) { tc = Color.BLACK; }
 
@@ -53,7 +53,7 @@ public class TextStyle {
         // default leading.
         ascent = rawAscent * factor;
         descent = rawDescent * -factor;
-        leading = descent / 2;
+        leading = descent * leadingFactor;
         // height = ascent + descent + leading;
 
         float avgFontWidth = 500;
@@ -67,7 +67,16 @@ public class TextStyle {
     }
 
     public static TextStyle of(PDType1Font f, float sz, Color tc) {
-        return new TextStyle(f, sz, tc);
+        return new TextStyle(f, sz, tc, 0.5f);
+    }
+    
+    /**
+     The leading factor defines the actual leading based on the font descent.
+     A leadingFactor of 1 will result of a leading equal to the descent, while a leadingFactor
+     of 2 will result of a leading equal to twice the descent etc...
+     */
+    public static TextStyle of(PDType1Font f, float sz, Color tc, float leadingFactor) {
+        return new TextStyle(f, sz, tc, leadingFactor);
     }
 
     /**


### PR DESCRIPTION
Hello,
Since Northern America is the only place where the default format paper is US Letter (21.6 × 27.9 cm), and many people (myself included) need to use A4 format (21 × 29.7 cm), I added the possibility to choose the document media box when calling newRgbPageMgr(). The default is still PDPage.PAGE_SIZE_LETTER.
Having the top and bottom margins depending on the newly customizable format, I changed that also, while adding the possibility to set them from the LogicalPage object. Keep in mind that the default values (i.e. a 37 top margin and a 0 bottom margin for US Letter format) are the same as before, so everything is backward compatible.
Anyway, thank you for this very convenient wrapper, feel free to comment and correct anything you deem necessary.